### PR TITLE
Version 5.0.1

### DIFF
--- a/app/Console/Commands/ManageRecurringInvoices.php
+++ b/app/Console/Commands/ManageRecurringInvoices.php
@@ -2,11 +2,11 @@
 
 namespace App\Console\Commands;
 
-use Carbon\Carbon;
-use App\Models\Invoice;
 use App\Mail\NewInvoice;
-use Illuminate\Console\Command;
+use App\Models\Invoice;
 use App\Models\RecurringInvoice;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
 
 class ManageRecurringInvoices extends Command
@@ -16,7 +16,7 @@ class ManageRecurringInvoices extends Command
      *
      * @var string
      */
-    protected $signature = 'invocies:recurring';
+    protected $signature = 'invoices:recurring';
 
     /**
      * The console command description.
@@ -43,9 +43,9 @@ class ManageRecurringInvoices extends Command
     public function handle()
     {
         $toMakeInvoices = RecurringInvoice::whereDate('next_run', '=', Carbon::today())
-                                            ->whereDate('last_run', '!=', Carbon::today())
-                                            ->get();
-        
+            ->whereDate('last_run', '!=', Carbon::today())
+            ->get();
+
         foreach ($toMakeInvoices as $completedInvoice) {
             $oldInvoice = Invoice::find($completedInvoice->invoice_id);
             $newInvoice = $oldInvoice->replicate();


### PR DESCRIPTION
- Fixes typo with artisan command: invoices:recurring

## Version 5.0.0

Version 5 is now running Laravel 5.5. This requires PHP 7.1.3 or higher. If you do not have this then either upgrade your PHP version or stay on version 4.0.2.

Version 5 brings the stable version of Bootstrap 4 to the front end and also an email is sent for overdue invoices and project acceptions. Many bug fixes were made and PHPUnit tests were added.

To upgrade just follow the upgrade instructions in the README file.